### PR TITLE
run redis fullcheck

### DIFF
--- a/ruby/run_redis_full_check.rb
+++ b/ruby/run_redis_full_check.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# value repair script
+require "io/console"
+
+p "source redis - endpoint:"
+source_redis_endpoint = STDIN.noecho(&:gets).chomp
+
+p "source redis - pwd"
+source_redis_pwd = STDIN.noecho(&:gets).chomp
+
+p "target memorydb endpoint:"
+target_memorydb_endpoint = STDIN.noecho(&:gets).chomp
+
+p "target memorydb - auth"
+target_memorydb_auth = STDIN.noecho(&:gets).chomp
+
+# call RedisFullCheck
+cmd = `../bin/redis-full-check -s #{source_redis_endpoint} -p #{source_redis_pwd} -t #{targete_redis_endpoint} -a #{target_memorydb_auth} --targetdbtype=1 --comparemode=2 --comparetimes=3`


### PR DESCRIPTION
Run RedisFullCheck via ruby script, so that we can provide auth / passwords without leaving record in console